### PR TITLE
Typo for linux

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -176,7 +176,7 @@ if(${WIN32})
 	SET_TARGET_PROPERTIES(${EXECUTABLE_NAME} PROPERTIES LINK_FLAGS " /MANIFEST:NO /ERRORREPORT:NONE")
 else()
 	# Linux
-	target_link_libraries(${EXECUTABLE_NAME} -Wl,-Bstatic ${Boost_LIBRARIES} ${POCO_LIBRARIES} ${MYSQL_LIBRARY}  -Wl,-Bdynamic ${TBB_MALLOC_LIBRARY}, -ldl -pthread -lz)
+	target_link_libraries(${EXECUTABLE_NAME} -Wl,-Bstatic ${Boost_LIBRARIES} ${POCO_LIBRARIES} ${MYSQL_LIBRARY}  -Wl,-Bdynamic ${TBB_MALLOC_LIBRARY} -ldl -pthread -lz)
 	set(CMAKE_CXX_FLAGS "-std=c++0x -static-libstdc++ -static-libgcc ${CMAKE_CXX_FLAGS}")
 
 	if (NOT((COMPILE_TEST_APPLICATION) OR (COMPILE_RCON_APPLICATION) OR (COMPILE_TEST_SANITIZE_APPLICATION)))


### PR DESCRIPTION
Caused it to search for libtbbmalloc.so, instead of libtbbmalloc.so